### PR TITLE
Change hook to fire AJAX callbacks

### DIFF
--- a/capsule-server-import-export.php
+++ b/capsule-server-import-export.php
@@ -203,5 +203,5 @@ function capsule_server_controller() {
 			break;
 	}
 }
-add_action('wp_loaded', 'capsule_server_controller');
+add_action( 'init', 'capsule_server_controller', 9998 );
 


### PR DESCRIPTION
Move AJAX callbacks in line before the capsule_gatekeeper() function hits. Avoids errors adding a capsule server to a local capsule environment.
